### PR TITLE
remove standard library conflicting types

### DIFF
--- a/include/stm8s.h
+++ b/include/stm8s.h
@@ -213,28 +213,8 @@
 #define     __O     volatile         /*!< defines 'write only' permissions    */
 #define     __IO    volatile         /*!< defines 'read / write' permissions  */
 
-/*!< Signed integer types  */
-typedef   signed char     int8_t;
-typedef   signed short    int16_t;
-typedef   signed long     int32_t;
-
-/*!< Unsigned integer types  */
-typedef unsigned char     uint8_t;
-typedef unsigned short    uint16_t;
-typedef unsigned long     uint32_t;
-
-/*!< STM8 Standard Peripheral Library old types (maintained for legacy purpose) */
-
-typedef int32_t  s32;
-typedef int16_t s16;
-typedef int8_t  s8;
-
-typedef uint32_t  u32;
-typedef uint16_t u16;
-typedef uint8_t  u8;
-
-
-typedef enum {FALSE = 0, TRUE = !FALSE} bool;
+/*!< Integer types  */
+#include <stdint.h>
 
 typedef enum {RESET = 0, SET = !RESET} FlagStatus, ITStatus, BitStatus, BitAction;
 


### PR DESCRIPTION
simply use `stdint.h` and `stdbool.h` instead